### PR TITLE
Python 2/3 compat fixes, and first demo apps with bundled python3.5

### DIFF
--- a/Demos/SimpleApp/SimpleApp.py
+++ b/Demos/SimpleApp/SimpleApp.py
@@ -19,7 +19,7 @@ class SimpleAppWindow(object):
         self.w.open()
 
     def buttonCallback(self, sender):
-        print("You pressed the button!")
+        print("You pressed the button!", flush=True)
 
 
 if __name__ == "__main__":

--- a/Demos/SimpleApp/SimpleApp.py
+++ b/Demos/SimpleApp/SimpleApp.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 from AppKit import NSObject
 from PyObjCTools import AppHelper
 import vanilla
@@ -18,7 +19,7 @@ class SimpleAppWindow(object):
         self.w.open()
 
     def buttonCallback(self, sender):
-        print "You pressed the button!"
+        print("You pressed the button!")
 
 
 if __name__ == "__main__":

--- a/Demos/TinyTextEditor/TinyTextEditor.py
+++ b/Demos/TinyTextEditor/TinyTextEditor.py
@@ -1,6 +1,7 @@
 from AppKit import NSDocument
 from PyObjCTools import AppHelper
 from tinyTextEditorDocumentWindow import TinyTextEditorDocumentWindow
+from io import open
 
 
 class TinyTextEditorDocument(NSDocument):
@@ -13,7 +14,7 @@ class TinyTextEditorDocument(NSDocument):
     
     def readFromFile_ofType_(self, path, tp):
         # refer to the NSDocument reference for information about this method
-        f = open(path, 'rb')
+        f = open(path, 'r', encoding='utf-8')
         text = f.read()
         f.close()
         self.vanillaWindowController.setText(text)
@@ -22,7 +23,7 @@ class TinyTextEditorDocument(NSDocument):
     def writeWithBackupToFile_ofType_saveOperation_(self, fileName, fileType, operation):
         # refer to the NSDocument reference for information about this method
         text = self.vanillaWindowController.getText()
-        f = open(fileName, 'wb')
+        f = open(fileName, 'w', encoding='utf-8')
         f.write(text)
         f.close()
         return True

--- a/Documentation/source/objects/FloatingWindow.rst
+++ b/Documentation/source/objects/FloatingWindow.rst
@@ -154,7 +154,7 @@ FloatingWindow
                 self.w.open()
 
             def windowMoved(sender):
-                print "window moved!", sender
+                print("window moved!", sender)
 
         WindowBindDemo()
 

--- a/Documentation/source/objects/Sheet.rst
+++ b/Documentation/source/objects/Sheet.rst
@@ -154,7 +154,7 @@ Sheet
                 self.w.open()
 
             def windowMoved(sender):
-                print "window moved!", sender
+                print("window moved!", sender)
 
         WindowBindDemo()
 

--- a/Documentation/source/objects/Window.rst
+++ b/Documentation/source/objects/Window.rst
@@ -156,7 +156,7 @@ Window
                 self.w.open()
 
             def windowMoved(self, sender):
-                print "window moved!", sender
+                print("window moved!", sender)
 
         WindowBindDemo()
 

--- a/Lib/vanilla/__init__.py
+++ b/Lib/vanilla/__init__.py
@@ -1,32 +1,32 @@
-from vanillaBase import VanillaBaseObject, VanillaBaseControl, VanillaError
-from vanillaBox import Box, HorizontalLine, VerticalLine
-from vanillaBrowser import ObjectBrowser
-from vanillaButton import Button, SquareButton, ImageButton, HelpButton
-from vanillaCheckBox import CheckBox
-from vanillaColorWell import ColorWell
-from vanillaComboBox import ComboBox
-from vanillaDatePicker import DatePicker
-from vanillaDrawer import Drawer
-from vanillaEditText import EditText, SecureEditText
-from vanillaGradientButton import GradientButton
-from vanillaGroup import Group
-from vanillaImageView import ImageView
-from vanillaLevelIndicator import LevelIndicator, LevelIndicatorListCell
-from vanillaList import List, CheckBoxListCell, SliderListCell, PopUpButtonListCell, ImageListCell, SegmentedButtonListCell
-from vanillaPathControl import PathControl
-from vanillaPopUpButton import PopUpButton, ActionButton
-from vanillaProgressBar import ProgressBar
-from vanillaProgressSpinner import ProgressSpinner
-from vanillaRadioGroup import RadioGroup
-from vanillaScrollView import ScrollView
-from vanillaSearchBox import SearchBox
-from vanillaSegmentedButton import SegmentedButton
-from vanillaSlider import Slider
-from vanillaSplitView2 import SplitView2
-from vanillaTabs import Tabs
-from vanillaTextBox import TextBox
-from vanillaTextEditor import TextEditor
-from vanillaWindows import Window, FloatingWindow, HUDFloatingWindow, Sheet
+from vanilla.vanillaBase import VanillaBaseObject, VanillaBaseControl, VanillaError
+from vanilla.vanillaBox import Box, HorizontalLine, VerticalLine
+from vanilla.vanillaBrowser import ObjectBrowser
+from vanilla.vanillaButton import Button, SquareButton, ImageButton, HelpButton
+from vanilla.vanillaCheckBox import CheckBox
+from vanilla.vanillaColorWell import ColorWell
+from vanilla.vanillaComboBox import ComboBox
+from vanilla.vanillaDatePicker import DatePicker
+from vanilla.vanillaDrawer import Drawer
+from vanilla.vanillaEditText import EditText, SecureEditText
+from vanilla.vanillaGradientButton import GradientButton
+from vanilla.vanillaGroup import Group
+from vanilla.vanillaImageView import ImageView
+from vanilla.vanillaLevelIndicator import LevelIndicator, LevelIndicatorListCell
+from vanilla.vanillaList import List, CheckBoxListCell, SliderListCell, PopUpButtonListCell, ImageListCell, SegmentedButtonListCell
+from vanilla.vanillaPathControl import PathControl
+from vanilla.vanillaPopUpButton import PopUpButton, ActionButton
+from vanilla.vanillaProgressBar import ProgressBar
+from vanilla.vanillaProgressSpinner import ProgressSpinner
+from vanilla.vanillaRadioGroup import RadioGroup
+from vanilla.vanillaScrollView import ScrollView
+from vanilla.vanillaSearchBox import SearchBox
+from vanilla.vanillaSegmentedButton import SegmentedButton
+from vanilla.vanillaSlider import Slider
+from vanilla.vanillaSplitView2 import SplitView2
+from vanilla.vanillaTabs import Tabs
+from vanilla.vanillaTextBox import TextBox
+from vanilla.vanillaTextEditor import TextEditor
+from vanilla.vanillaWindows import Window, FloatingWindow, HUDFloatingWindow, Sheet
 
 __all__ = [
     "VanillaBaseObject", "VanillaBaseControl", "VanillaError",
@@ -64,7 +64,7 @@ __all__ = [
 
 # OS 10.7 objects
 try:
-    from vanillaPopover import Popover
+    from vanilla.vanillaPopover import Popover
     __all__.append("Popover")
 except (ImportError, NameError):
     pass
@@ -76,7 +76,7 @@ class _NoRBSplitView(object):
         raise VanillaError("SplitView is not available because the RBSplitView framework cannot be found. Refer to the Vanilla documentation for details.")
 
 try:
-    from vanillaSplitView import SplitView
+    from vanilla.vanillaSplitView import SplitView
     from vanilla.externalFrameworks import RBSplitView
 except (ImportError, ValueError):
     SplitView = _NoRBSplitView

--- a/Lib/vanilla/dialogs.py
+++ b/Lib/vanilla/dialogs.py
@@ -31,6 +31,7 @@ class BaseMessageDialog(NSObject):
             alert.beginSheetModalForWindow_modalDelegate_didEndSelector_contextInfo_(parentWindow, self, "alertDidEnd:returnCode:contextInfo:", 0)
         return self
 
+    @objc.python_method
     def _translateValue(self, code):
         if code == NSAlertFirstButtonReturn:
             value = 1

--- a/Lib/vanilla/nsSubclasses.py
+++ b/Lib/vanilla/nsSubclasses.py
@@ -1,6 +1,8 @@
 import objc
 import weakref
 
+from vanilla.py23 import basestring
+
 
 class _VanillaMethods:
 

--- a/Lib/vanilla/py23.py
+++ b/Lib/vanilla/py23.py
@@ -14,3 +14,8 @@ try:
     long = long
 except NameError:
     long = int
+
+try:
+    range = xrange
+except NameError:
+    range = range

--- a/Lib/vanilla/py23.py
+++ b/Lib/vanilla/py23.py
@@ -1,0 +1,11 @@
+__all__ = ['unicode', 'long']
+
+# In Python 3, unicode == str, and long == int
+try:
+    unicode = unicode
+except NameError:
+    unicode = str
+try:
+    long = long
+except NameError:
+    long = int

--- a/Lib/vanilla/py23.py
+++ b/Lib/vanilla/py23.py
@@ -19,3 +19,8 @@ try:
     range = xrange
 except NameError:
     range = range
+
+try:
+    unichr = unichr
+except NameError:
+    unichr = chr

--- a/Lib/vanilla/py23.py
+++ b/Lib/vanilla/py23.py
@@ -1,10 +1,15 @@
-__all__ = ['unicode', 'long']
+__all__ = ['basestring', 'unicode', 'long']
 
-# In Python 3, unicode == str, and long == int
+try:
+    basestring = basestring
+except NameError:
+    basestring = str
+
 try:
     unicode = unicode
 except NameError:
     unicode = str
+
 try:
     long = long
 except NameError:

--- a/Lib/vanilla/test/testAll.py
+++ b/Lib/vanilla/test/testAll.py
@@ -21,9 +21,9 @@ iconPath = os.path.join(vanillaPath, "Data", "testIcon.tif")
 
 sizeStyles = ["regular", "small", "mini"]
 
-listOptions = sys.modules.keys()
-sortedListOptions = list(listOptions)
-sortedListOptions.sort()
+listOptions = list(sys.modules.keys())
+sortedListOptions = sorted(listOptions)
+
 
 class BaseTest(object):
 

--- a/Lib/vanilla/test/testAll.py
+++ b/Lib/vanilla/test/testAll.py
@@ -10,6 +10,7 @@ except NameError:
     # the built-in 'reload' was moved to importlib with Python 3.4
     from importlib import reload
     reload(vanilla)
+from vanilla.py23 import range
 from vanilla import *
 
 import objc
@@ -29,13 +30,13 @@ class BaseTest(object):
     def drawGrid(self):
         w, h = self.w.getPosSize()[2:]
         increment = 10
-        for i in xrange(int(w/increment)):
+        for i in range(int(w/increment)):
             if i == 0:
                 continue
             attrName = "vline%d" % i
             line = VerticalLine((increment*i, 0, 1, h))
             setattr(self.w, attrName, line)
-        for i in xrange(int(h/increment)):
+        for i in range(int(h/increment)):
             if i == 0:
                 continue
             attrName = "hline%d" % i
@@ -401,8 +402,8 @@ class TestCustomNSView(NSView):
         width, height = self.frame()[1]
         w = width / 5
         h = height / 5
-        for xI in xrange(5):
-            for yI in xrange(5):
+        for xI in range(5):
+            for yI in range(5):
                 x = xI * w
                 y = height - (yI * h) - h
                 r = ((x, y), (w, h))
@@ -504,7 +505,7 @@ class MiscTest(BaseTest):
         self.w.spinner1.start()
         self.w.spinner2.start()
         self.w.bar2.start()
-        for i in xrange(10):
+        for i in range(10):
             self.w.bar1.increment(10)
             time.sleep(.1)
         time.sleep(.5)

--- a/Lib/vanilla/test/testAll.py
+++ b/Lib/vanilla/test/testAll.py
@@ -3,7 +3,12 @@ import os
 import sys
 from AppKit import *
 import vanilla
-reload(vanilla)
+try:
+    reload(vanilla)
+except NameError:
+    # the built-in 'reload' was moved to importlib with Python 3.4
+    from importlib import reload
+    reload(vanilla)
 from vanilla import *
 
 import objc

--- a/Lib/vanilla/test/testAll.py
+++ b/Lib/vanilla/test/testAll.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 import time
 import os
 import sys
@@ -42,13 +43,13 @@ class BaseTest(object):
             setattr(self.w, attrName, line)
 
     def basicCallback(self, sender):
-        print sender
+        print(sender)
 
     def titleCallback(self, sender):
-        print sender, sender.getTitle()
+        print(sender, sender.getTitle())
 
     def getCallback(self, sender):
-        print sender, sender.get()
+        print(sender, sender.get())
 
 
 class WindowTest(BaseTest):

--- a/Lib/vanilla/vanillaBase.py
+++ b/Lib/vanilla/vanillaBase.py
@@ -1,7 +1,7 @@
 import platform
 from AppKit import *
 from distutils.version import StrictVersion
-from nsSubclasses import getNSSubclass
+from vanilla.nsSubclasses import getNSSubclass
 
 osVersionCurrent = StrictVersion(platform.mac_ver()[0])
 osVersion10_12 = StrictVersion("10.12")

--- a/Lib/vanilla/vanillaBox.py
+++ b/Lib/vanilla/vanillaBox.py
@@ -1,5 +1,5 @@
 from AppKit import *
-from vanillaBase import VanillaBaseObject, _breakCycles, osVersionCurrent, osVersion10_10
+from vanilla.vanillaBase import VanillaBaseObject, _breakCycles, osVersionCurrent, osVersion10_10
 
 
 class Box(VanillaBaseObject):

--- a/Lib/vanilla/vanillaBrowser.py
+++ b/Lib/vanilla/vanillaBrowser.py
@@ -163,7 +163,7 @@ def getArguments(obj):
     and leave 'self' out.
     """
     try:
-        arguments = apply(inspect.formatargspec, inspect.getargspec(obj))
+        arguments = inspect.formatargspec(*inspect.getargspec(obj))
     except TypeError:
         arguments = ""
     return arguments.replace("self, ", "").replace("self", "")

--- a/Lib/vanilla/vanillaBrowser.py
+++ b/Lib/vanilla/vanillaBrowser.py
@@ -266,7 +266,7 @@ class PythonItem(AppKit.NSObject):
 
     @objc.python_method
     def getChild(self, child):
-        if self._childRefs.has_key(child):
+        if child in self._childRefs:
             return self._childRefs[child]
 
         name = self.children[child]

--- a/Lib/vanilla/vanillaBrowser.py
+++ b/Lib/vanilla/vanillaBrowser.py
@@ -3,6 +3,7 @@ This is adapted from the PyObjC PythonBrowser demo.
 I beleive that demo was written by Just van Rossum.
 """
 
+import objc
 import AppKit
 from operator import getitem, setitem
 
@@ -251,11 +252,13 @@ class PythonItem(AppKit.NSObject):
             self.children = [child for child in self.children if not (isinstance(child, (str, unicode)) and hasattr(AppKit, child))]
 
         self._childRefs = {}
-    
+
+    @objc.python_method
     def _setSetters(self, names, callback):
         for name in names:
             self.setters[name] = callback
-    
+
+    @objc.python_method
     def _setGetters(self, names, callback):
         for name in names:
             self.getters[name] = callback
@@ -263,6 +266,7 @@ class PythonItem(AppKit.NSObject):
     def isExpandable(self):
         return bool(self.children)
 
+    @objc.python_method
     def getChild(self, child):
         if self._childRefs.has_key(child):
             return self._childRefs[child]

--- a/Lib/vanilla/vanillaBrowser.py
+++ b/Lib/vanilla/vanillaBrowser.py
@@ -207,8 +207,7 @@ class PythonItem(AppKit.NSObject):
         self.getters = dict()
         self.setters = dict()
         if isinstance(obj, dict):
-            self.children = obj.keys()
-            self.children.sort()
+            self.children = sorted(obj.keys())
             self._setGetters(self.children, getitem)
             self._setSetters(self.children, setitem)
         elif obj is None or isinstance(obj, SIMPLE_TYPES):
@@ -234,8 +233,7 @@ class PythonItem(AppKit.NSObject):
             
             try:
                 d = dict(obj)
-                self.children = d.keys()
-                self.children.sort()
+                self.children = sorted(d.keys())
                 self._setGetters(self.children, getitem)
                 self._setSetters(self.children, setitem)
             except:

--- a/Lib/vanilla/vanillaBrowser.py
+++ b/Lib/vanilla/vanillaBrowser.py
@@ -8,6 +8,7 @@ from operator import getitem, setitem
 
 import inspect
 
+from vanilla.py23 import unicode, long
 from vanilla.vanillaBase import VanillaBaseObject
 from vanilla.nsSubclasses import getNSSubclass
 

--- a/Lib/vanilla/vanillaBrowser.py
+++ b/Lib/vanilla/vanillaBrowser.py
@@ -9,7 +9,7 @@ from operator import getitem, setitem
 
 import inspect
 
-from vanilla.py23 import unicode, long
+from vanilla.py23 import unicode, long, range
 from vanilla.vanillaBase import VanillaBaseObject
 from vanilla.nsSubclasses import getNSSubclass
 
@@ -214,7 +214,7 @@ class PythonItem(AppKit.NSObject):
         elif obj is None or isinstance(obj, SIMPLE_TYPES):
             pass
         elif isinstance(obj, (list, tuple, set)):
-            self.children = range(len(obj))
+            self.children = list(range(len(obj)))
             self._setGetters(self.children, getitem)
             self._setSetters(self.children, setitem)
         elif isinstance(obj, property):
@@ -226,7 +226,7 @@ class PythonItem(AppKit.NSObject):
         else:
             try:
                 l = list(obj)
-                self.children = range(len(l))
+                self.children = list(range(len(l)))
                 self._setGetters(self.children, getitem)
                 self._setSetters(self.children, setitem)
             except:

--- a/Lib/vanilla/vanillaButton.py
+++ b/Lib/vanilla/vanillaButton.py
@@ -312,7 +312,7 @@ class ImageButton(SquareButton):
         elif imageObject is not None:
             image = imageObject
         else:
-            raise ValueError, "no image source defined"
+            raise ValueError("no image source defined")
         self._nsObject.setImage_(image)
 
 

--- a/Lib/vanilla/vanillaButton.py
+++ b/Lib/vanilla/vanillaButton.py
@@ -1,5 +1,5 @@
 from AppKit import *
-from vanillaBase import VanillaBaseControl
+from vanilla.vanillaBase import VanillaBaseControl
 
 
 _modifierMap = {

--- a/Lib/vanilla/vanillaButton.py
+++ b/Lib/vanilla/vanillaButton.py
@@ -40,7 +40,7 @@ class Button(VanillaBaseControl):
                  self.w.open()
 
              def buttonCallback(self, sender):
-                 print "button hit!"
+                 print("button hit!")
 
         ButtonDemo()
 
@@ -170,7 +170,7 @@ class SquareButton(Button):
                  self.w.open()
 
              def buttonCallback(self, sender):
-                 print "button hit!"
+                 print("button hit!")
 
         SquareButtonDemo()
 
@@ -222,7 +222,7 @@ class ImageButton(SquareButton):
                  self.w.open()
 
              def buttonCallback(self, sender):
-                 print "button hit!"
+                 print("button hit!")
 
         ImageButtonDemo()
 
@@ -332,7 +332,7 @@ class HelpButton(Button):
                  self.w.open()
 
              def buttonCallback(self, sender):
-                 print "help button hit!"
+                 print("help button hit!")
 
         HelpButtonDemo()
 

--- a/Lib/vanilla/vanillaCheckBox.py
+++ b/Lib/vanilla/vanillaCheckBox.py
@@ -1,6 +1,6 @@
 from AppKit import *
-from vanillaButton import Button
-from vanillaBase import osVersionCurrent, osVersion10_10, VanillaBaseObject
+from vanilla.vanillaButton import Button
+from vanilla.vanillaBase import osVersionCurrent, osVersion10_10, VanillaBaseObject
 
 
 # In OS 10.0-10.X (tested up to OS 10.4) the small and mini check box

--- a/Lib/vanilla/vanillaCheckBox.py
+++ b/Lib/vanilla/vanillaCheckBox.py
@@ -24,7 +24,7 @@ A standard check box.::
             self.w.open()
 
         def checkBoxCallback(self, sender):
-            print "check box state change!", sender.get()
+            print("check box state change!", sender.get())
 
     CheckBoxDemo()
 

--- a/Lib/vanilla/vanillaColorWell.py
+++ b/Lib/vanilla/vanillaColorWell.py
@@ -1,5 +1,5 @@
 from AppKit import *
-from vanillaBase import VanillaBaseObject
+from vanilla.vanillaBase import VanillaBaseObject
 
 
 class ColorWell(VanillaBaseObject):

--- a/Lib/vanilla/vanillaColorWell.py
+++ b/Lib/vanilla/vanillaColorWell.py
@@ -23,7 +23,7 @@ class ColorWell(VanillaBaseObject):
                 self.w.open()
 
             def colorWellEdit(self, sender):
-                print "color well edit!", sender.get()
+                print("color well edit!", sender.get())
 
         ColorWellDemo()
 

--- a/Lib/vanilla/vanillaComboBox.py
+++ b/Lib/vanilla/vanillaComboBox.py
@@ -45,7 +45,7 @@ class ComboBox(VanillaBaseControl):
                 self.w.open()
 
             def comboBoxCallback(self, sender):
-                print "combo box entry!", sender.get()
+                print("combo box entry!", sender.get())
 
         ComboBoxDemo()
 

--- a/Lib/vanilla/vanillaComboBox.py
+++ b/Lib/vanilla/vanillaComboBox.py
@@ -1,5 +1,5 @@
 from AppKit import NSObject, NSComboBox
-from vanillaBase import VanillaBaseControl
+from vanilla.vanillaBase import VanillaBaseControl
 
 
 class VanillaComboBoxDelegate(NSObject):

--- a/Lib/vanilla/vanillaComboBox.py
+++ b/Lib/vanilla/vanillaComboBox.py
@@ -1,3 +1,4 @@
+import objc
 from AppKit import NSObject, NSComboBox
 from vanilla.vanillaBase import VanillaBaseControl
 
@@ -6,6 +7,7 @@ class VanillaComboBoxDelegate(NSObject):
 
     _continuous = True
 
+    @objc.python_method
     def _callVanillaCallback(self, notification):
         obj = notification.object()
         target = obj.target()

--- a/Lib/vanilla/vanillaDatePicker.py
+++ b/Lib/vanilla/vanillaDatePicker.py
@@ -1,6 +1,6 @@
 from Foundation import *
 from AppKit import *
-from vanillaBase import VanillaBaseControl
+from vanilla.vanillaBase import VanillaBaseControl
 
 
 _modeMap = {

--- a/Lib/vanilla/vanillaDrawer.py
+++ b/Lib/vanilla/vanillaDrawer.py
@@ -1,6 +1,6 @@
 from Foundation import NSMaxXEdge, NSMaxYEdge, NSMinXEdge, NSMinYEdge
 from AppKit import *
-from vanillaBase import VanillaBaseObject, _breakCycles
+from vanilla.vanillaBase import VanillaBaseObject, _breakCycles
 
 
 _drawerEdgeMap = {
@@ -71,7 +71,7 @@ class Drawer(VanillaBaseObject):
 
     def __init__(self, size, parentWindow, minSize=None, maxSize=None,
             preferredEdge="left", forceEdge=False, leadingOffset=20, trailingOffset=20):
-        from vanillaWindows import Window
+        from vanilla.vanillaWindows import Window
         self._preferredEdge = preferredEdge
         self._forceEdge = forceEdge
         drawer = self._nsObject = self.nsDrawerClass.alloc().initWithContentSize_preferredEdge_(

--- a/Lib/vanilla/vanillaEditText.py
+++ b/Lib/vanilla/vanillaEditText.py
@@ -1,5 +1,5 @@
 from AppKit import *
-from vanillaBase import VanillaBaseControl, VanillaCallbackWrapper
+from vanilla.vanillaBase import VanillaBaseControl, VanillaCallbackWrapper
 
 
 class VanillaEditTextDelegate(VanillaCallbackWrapper):

--- a/Lib/vanilla/vanillaEditText.py
+++ b/Lib/vanilla/vanillaEditText.py
@@ -31,7 +31,7 @@ class EditText(VanillaBaseControl):
                 self.w.open()
 
             def editTextCallback(self, sender):
-                print "text entry!", sender.get()
+                print("text entry!", sender.get())
 
         EditTextDemo()
 
@@ -166,7 +166,7 @@ class SecureEditText(EditText):
                 self.w.open()
 
             def secureEditTextCallback(self, sender):
-                print "text entry!", sender.get()
+                print("text entry!", sender.get())
 
         SecureEditTextDemo()
 

--- a/Lib/vanilla/vanillaGradientButton.py
+++ b/Lib/vanilla/vanillaGradientButton.py
@@ -1,5 +1,5 @@
 from AppKit import *
-from vanillaButton import ImageButton
+from vanilla.vanillaButton import ImageButton
 
 
 class GradientButton(ImageButton):

--- a/Lib/vanilla/vanillaGroup.py
+++ b/Lib/vanilla/vanillaGroup.py
@@ -1,5 +1,5 @@
 from AppKit import NSView
-from vanillaBase import VanillaBaseObject, osVersionCurrent, osVersion10_10
+from vanilla.vanillaBase import VanillaBaseObject, osVersionCurrent, osVersion10_10
 
 try:
     NSVisualEffectMaterialAppearanceBased

--- a/Lib/vanilla/vanillaImageView.py
+++ b/Lib/vanilla/vanillaImageView.py
@@ -1,5 +1,5 @@
 from AppKit import *
-from vanillaBase import VanillaBaseObject
+from vanilla.vanillaBase import VanillaBaseObject
 
 _imageAlignmentMap = {
     ("center", "center") : NSImageAlignCenter,

--- a/Lib/vanilla/vanillaImageView.py
+++ b/Lib/vanilla/vanillaImageView.py
@@ -99,5 +99,5 @@ class ImageView(VanillaBaseObject):
         elif imageObject is not None:
             image = imageObject
         else:
-            raise ValueError, "no image source defined"
+            raise ValueError("no image source defined")
         self._nsObject.setImage_(image)

--- a/Lib/vanilla/vanillaLevelIndicator.py
+++ b/Lib/vanilla/vanillaLevelIndicator.py
@@ -1,5 +1,5 @@
 from AppKit import *
-from vanillaBase import VanillaBaseControl
+from vanilla.vanillaBase import VanillaBaseControl
 
 # This control is available in OS 10.4+.
 # Cause a NameError if in an earlier OS.

--- a/Lib/vanilla/vanillaLevelIndicator.py
+++ b/Lib/vanilla/vanillaLevelIndicator.py
@@ -38,7 +38,7 @@ class LevelIndicator(VanillaBaseControl):
                  self.w.open()
 
              def levelIndicatorCallback(self, sender):
-                 print "level indicator edit!", sender.get()
+                 print("level indicator edit!", sender.get())
 
         LevelIndicatorDemo()
 

--- a/Lib/vanilla/vanillaList.py
+++ b/Lib/vanilla/vanillaList.py
@@ -79,6 +79,7 @@ class VanillaArrayController(NSArrayController):
         pboard.setPropertyList_forType_(objects.description(), dragType)
         return True
 
+    @objc.python_method
     def _handleDrop(self, isProposal, tableView, draggingInfo, row, dropOperation):
         vanillaWrapper = tableView.vanillaWrapper()
         draggingSource = draggingInfo.draggingSource()
@@ -121,6 +122,7 @@ class VanillaArrayController(NSArrayController):
         settings = vanillaWrapper._otherApplicationDropSettings
         return self._handleDropBasedOnSettings(settings, vanillaWrapper, dropOnRow, draggingInfo, dropInformation)
 
+    @objc.python_method
     def _handleDropBasedOnSettings(self, settings, vanillaWrapper, dropOnRow, draggingInfo, dropInformation):
         # handle drop position
         validDropPosition = self._validateDropPosition(settings, dropOnRow)
@@ -134,6 +136,7 @@ class VanillaArrayController(NSArrayController):
             return settings.get("operation", NSDragOperationCopy)
         return NSDragOperationNone
 
+    @objc.python_method
     def _validateDropPosition(self, settings, dropOnRow):
         if dropOnRow and not settings.get("allowsDropOnRows", False):
             return False
@@ -141,6 +144,7 @@ class VanillaArrayController(NSArrayController):
             return False
         return True
 
+    @objc.python_method
     def _unpackPboard(self, settings, draggingInfo):
         pboard = draggingInfo.draggingPasteboard()
         data = pboard.propertyListForType_(settings["type"])

--- a/Lib/vanilla/vanillaList.py
+++ b/Lib/vanilla/vanillaList.py
@@ -2,8 +2,8 @@ import time
 import objc
 from Foundation import NSKeyValueObservingOptionNew, NSKeyValueObservingOptionOld, NSNotFound
 from AppKit import *
-from nsSubclasses import getNSSubclass
-from vanillaBase import VanillaBaseObject, VanillaError, VanillaCallbackWrapper
+from vanilla.nsSubclasses import getNSSubclass
+from vanilla.vanillaBase import VanillaBaseObject, VanillaError, VanillaCallbackWrapper
 
 
 class VanillaTableViewSubclass(NSTableView):
@@ -1241,7 +1241,7 @@ def ImageListCell(horizontalAlignment="center", verticalAlignment="center", scal
 
         ImageListCellDemo()
     """
-    from vanillaImageView import _imageAlignmentMap, _imageScaleMap
+    from vanilla.vanillaImageView import _imageAlignmentMap, _imageScaleMap
     cell = NSImageCell.alloc().init()
     align = _imageAlignmentMap[(horizontalAlignment, verticalAlignment)]
     cell.setImageAlignment_(align)

--- a/Lib/vanilla/vanillaList.py
+++ b/Lib/vanilla/vanillaList.py
@@ -2,7 +2,7 @@ import time
 import objc
 from Foundation import NSKeyValueObservingOptionNew, NSKeyValueObservingOptionOld, NSNotFound
 from AppKit import *
-from vanilla.py23 import basestring, range
+from vanilla.py23 import basestring, range, unichr
 from vanilla.nsSubclasses import getNSSubclass
 from vanilla.vanillaBase import VanillaBaseObject, VanillaError, VanillaCallbackWrapper
 

--- a/Lib/vanilla/vanillaList.py
+++ b/Lib/vanilla/vanillaList.py
@@ -205,7 +205,7 @@ class List(VanillaBaseObject):
                 self.w.open()
 
             def selectionCallback(self, sender):
-                print sender.getSelection()
+                print(sender.getSelection())
 
         ListDemo()
 
@@ -224,7 +224,7 @@ class List(VanillaBaseObject):
                 self.w.open()
 
             def selectionCallback(self, sender):
-                print sender.getSelection()
+                print(sender.getSelection())
 
         ListDemo()
 
@@ -1072,7 +1072,7 @@ def CheckBoxListCell(title=None):
                 self.w.open()
 
             def editCallback(self, sender):
-                print sender.get()
+                print(sender.get())
 
         CheckBoxListCellDemo()
     """
@@ -1122,7 +1122,7 @@ def SliderListCell(minValue=0, maxValue=100, tickMarkCount=None, stopOnTickMarks
                 self.w.open()
 
             def editCallback(self, sender):
-                print sender.get()
+                print(sender.get())
 
         SliderListCellDemo()
     """
@@ -1166,7 +1166,7 @@ def PopUpButtonListCell(items):
                 self.w.open()
 
             def editCallback(self, sender):
-                print sender.get()
+                print(sender.get())
 
         PopUpButtonListCellDemo()
     """
@@ -1293,7 +1293,7 @@ def SegmentedButtonListCell(segmentDescriptions):
                 self.w.open()
 
             def editCallback(self, sender):
-                print sender.get()
+                print(sender.get())
 
         SegmentedButtonListCellDemo()
     """

--- a/Lib/vanilla/vanillaList.py
+++ b/Lib/vanilla/vanillaList.py
@@ -2,6 +2,7 @@ import time
 import objc
 from Foundation import NSKeyValueObservingOptionNew, NSKeyValueObservingOptionOld, NSNotFound
 from AppKit import *
+from vanilla.py23 import basestring
 from vanilla.nsSubclasses import getNSSubclass
 from vanilla.vanillaBase import VanillaBaseObject, VanillaError, VanillaCallbackWrapper
 

--- a/Lib/vanilla/vanillaList.py
+++ b/Lib/vanilla/vanillaList.py
@@ -2,7 +2,7 @@ import time
 import objc
 from Foundation import NSKeyValueObservingOptionNew, NSKeyValueObservingOptionOld, NSNotFound
 from AppKit import *
-from vanilla.py23 import basestring
+from vanilla.py23 import basestring, range
 from vanilla.nsSubclasses import getNSSubclass
 from vanilla.vanillaBase import VanillaBaseObject, VanillaError, VanillaCallbackWrapper
 
@@ -795,7 +795,7 @@ class List(VanillaBaseObject):
             lastResort = None
             lastResortIndex = None
             inputLength = len(inputString)
-            for index in xrange(len(self)):
+            for index in range(len(self)):
                 item = self._arrayController.content()[index]
                 # the item could be a dictionary or
                 # a NSObject. safely handle each.
@@ -1011,8 +1011,7 @@ class List(VanillaBaseObject):
         # find the indexes of the ubsorted objects matching
         # the sorted objects
         unsortedIndexes = []
-        for index in xrange(len(unsortedArray)):
-            obj = unsortedArray[index]
+        for index, obj in enumerate(unsortedArray):
             test = (id(obj), obj)
             if test in sortedObjects:
                 unsortedIndexes.append(index)
@@ -1037,8 +1036,7 @@ class List(VanillaBaseObject):
         # find the indexes of the sorted objects matching
         # the unsorted objects
         sortedIndexes = []
-        for index in xrange(len(sortedArray)):
-            obj = sortedArray[index]
+        for index, obj in enumerate(sortedArray):
             test = (id(obj), obj)
             if test in unsortedObjects:
                 sortedIndexes.append(index)

--- a/Lib/vanilla/vanillaPathControl.py
+++ b/Lib/vanilla/vanillaPathControl.py
@@ -1,5 +1,5 @@
 from AppKit import *
-from vanillaBase import VanillaBaseControl
+from vanilla.vanillaBase import VanillaBaseControl
 
 class PathControl(VanillaBaseControl):
 

--- a/Lib/vanilla/vanillaPopUpButton.py
+++ b/Lib/vanilla/vanillaPopUpButton.py
@@ -1,5 +1,5 @@
 from AppKit import NSPopUpButton, NSPopUpButtonCell, NSMenuItem, NSImageNameActionTemplate, NSImage, NSMenu, NSTexturedRoundedBezelStyle
-from vanillaBase import VanillaBaseControl, VanillaCallbackWrapper, _reverseSizeStyleMap
+from vanilla.vanillaBase import VanillaBaseControl, VanillaCallbackWrapper, _reverseSizeStyleMap
 
 
 class PopUpButton(VanillaBaseControl):

--- a/Lib/vanilla/vanillaPopUpButton.py
+++ b/Lib/vanilla/vanillaPopUpButton.py
@@ -19,7 +19,7 @@ class PopUpButton(VanillaBaseControl):
                 self.w.open()
 
             def popUpButtonCallback(self, sender):
-                print "pop up button selection!", sender.get()
+                print("pop up button selection!", sender.get())
 
         PopUpButtonDemo()
 
@@ -144,13 +144,13 @@ class ActionButton(PopUpButton):
                 self.w.open()
 
             def firstCallback(self, sender):
-                print "first"
+                print("first")
             
             def secondCallback(self, sender):
-                print "second"
+                print("second")
             
             def subFirstCallback(self, sender):
-                print "sub first"
+                print("sub first")
 
         ActionPopUpButtonDemo()
     

--- a/Lib/vanilla/vanillaPopover.py
+++ b/Lib/vanilla/vanillaPopover.py
@@ -1,7 +1,7 @@
 import weakref
 from AppKit import *
-from vanillaBase import VanillaBaseObject, _breakCycles
-from nsSubclasses import getNSSubclass
+from vanilla.vanillaBase import VanillaBaseObject, _breakCycles
+from vanilla.nsSubclasses import getNSSubclass
 
 _edgeMap = {
     "left" : NSMinXEdge,

--- a/Lib/vanilla/vanillaProgressBar.py
+++ b/Lib/vanilla/vanillaProgressBar.py
@@ -1,5 +1,5 @@
 from AppKit import *
-from vanillaBase import VanillaBaseObject, _sizeStyleMap, osVersion10_11, osVersionCurrent
+from vanilla.vanillaBase import VanillaBaseObject, _sizeStyleMap, osVersion10_11, osVersionCurrent
 
 class ProgressBar(VanillaBaseObject):
 

--- a/Lib/vanilla/vanillaProgressSpinner.py
+++ b/Lib/vanilla/vanillaProgressSpinner.py
@@ -1,5 +1,5 @@
 from AppKit import *
-from vanillaBase import VanillaBaseObject, _sizeStyleMap
+from vanilla.vanillaBase import VanillaBaseObject, _sizeStyleMap
 
 
 class ProgressSpinner(VanillaBaseObject):

--- a/Lib/vanilla/vanillaRadioGroup.py
+++ b/Lib/vanilla/vanillaRadioGroup.py
@@ -1,5 +1,5 @@
 from AppKit import *
-from vanillaBase import VanillaBaseControl, _sizeStyleMap
+from vanilla.vanillaBase import VanillaBaseControl, _sizeStyleMap
 
 
 class RadioGroup(VanillaBaseControl):

--- a/Lib/vanilla/vanillaRadioGroup.py
+++ b/Lib/vanilla/vanillaRadioGroup.py
@@ -1,4 +1,5 @@
 from AppKit import *
+from vanilla.py23 import range
 from vanilla.vanillaBase import VanillaBaseControl, _sizeStyleMap
 
 
@@ -72,7 +73,7 @@ class RadioGroup(VanillaBaseControl):
             matrix.setCellSize_((posSize[2], 12))
         else:
             raise ValueError("sizeStyle must be 'regular', 'small' or 'mini'")
-        for x in range(len(titles)):
+        for _ in range(len(titles)):
             if isVertical:
                 matrix.addRow()
             else:

--- a/Lib/vanilla/vanillaRadioGroup.py
+++ b/Lib/vanilla/vanillaRadioGroup.py
@@ -19,7 +19,7 @@ class RadioGroup(VanillaBaseControl):
                 self.w.open()
 
             def radioGroupCallback(self, sender):
-                print "radio group edit!", sender.get()
+                print("radio group edit!", sender.get())
 
         RadioGroupDemo()
 

--- a/Lib/vanilla/vanillaScrollView.py
+++ b/Lib/vanilla/vanillaScrollView.py
@@ -1,5 +1,5 @@
 from AppKit import *
-from vanillaBase import VanillaBaseObject
+from vanilla.vanillaBase import VanillaBaseObject
 
 
 class ScrollView(VanillaBaseObject):

--- a/Lib/vanilla/vanillaSearchBox.py
+++ b/Lib/vanilla/vanillaSearchBox.py
@@ -1,5 +1,5 @@
 from AppKit import NSSearchField
-from vanillaBase import VanillaBaseControl
+from vanilla.vanillaBase import VanillaBaseControl
 
 
 class SearchBox(VanillaBaseControl):

--- a/Lib/vanilla/vanillaSearchBox.py
+++ b/Lib/vanilla/vanillaSearchBox.py
@@ -18,7 +18,7 @@ class SearchBox(VanillaBaseControl):
                 self.w.open()
 
             def searchBoxCallback(self, sender):
-                print "search box entry!", sender.get()
+                print("search box entry!", sender.get())
 
         SearchBoxDemo()
 

--- a/Lib/vanilla/vanillaSegmentedButton.py
+++ b/Lib/vanilla/vanillaSegmentedButton.py
@@ -1,4 +1,5 @@
 from AppKit import *
+from vanilla.py23 import range
 from vanilla.vanillaBase import VanillaBaseControl
 
 
@@ -134,7 +135,7 @@ class SegmentedButton(VanillaBaseControl):
         """
         Enable or disable the object. **onOff** should be a boolean.
         """
-        for index in xrange(self._nsObject.segmentCount()):
+        for index in range(self._nsObject.segmentCount()):
             self._nsObject.setEnabled_forSegment_(onOff, index)
 
     def set(self, value):
@@ -146,7 +147,7 @@ class SegmentedButton(VanillaBaseControl):
         # value should be an int unless we are in "any" mode
         if self._nsObject.cell().trackingMode() != _trackingModeMap["any"]:
             value = [value]
-        for index in xrange(self._nsObject.segmentCount()):
+        for index in range(self._nsObject.segmentCount()):
             state = index in value
             self._nsObject.setSelected_forSegment_(state, index)
 
@@ -157,7 +158,7 @@ class SegmentedButton(VanillaBaseControl):
         Otherwise the returned value will be a single integer.
         """
         states = []
-        for index in xrange(self._nsObject.segmentCount()):
+        for index in range(self._nsObject.segmentCount()):
             state = self._nsObject.isSelectedForSegment_(index)
             if state:
                 states.append(index)

--- a/Lib/vanilla/vanillaSegmentedButton.py
+++ b/Lib/vanilla/vanillaSegmentedButton.py
@@ -1,5 +1,5 @@
 from AppKit import *
-from vanillaBase import VanillaBaseControl
+from vanilla.vanillaBase import VanillaBaseControl
 
 
 _trackingModeMap = {

--- a/Lib/vanilla/vanillaSegmentedButton.py
+++ b/Lib/vanilla/vanillaSegmentedButton.py
@@ -26,7 +26,7 @@ class SegmentedButton(VanillaBaseControl):
                  self.w.open()
 
              def buttonCallback(self, sender):
-                 print "button hit!"
+                 print("button hit!")
 
         SegmentedButtonDemo()
 

--- a/Lib/vanilla/vanillaSlider.py
+++ b/Lib/vanilla/vanillaSlider.py
@@ -27,7 +27,7 @@ class Slider(VanillaBaseControl):
                  self.w.open()
 
              def sliderCallback(self, sender):
-                 print "slider edit!", sender.get()
+                 print("slider edit!", sender.get())
 
         SliderDemo()
 

--- a/Lib/vanilla/vanillaSlider.py
+++ b/Lib/vanilla/vanillaSlider.py
@@ -1,5 +1,5 @@
 from AppKit import *
-from vanillaBase import VanillaBaseControl, VanillaError
+from vanilla.vanillaBase import VanillaBaseControl, VanillaError
 
 _tickPositionMap = {
     "left": NSTickMarkLeft,

--- a/Lib/vanilla/vanillaSplitView.py
+++ b/Lib/vanilla/vanillaSplitView.py
@@ -16,6 +16,7 @@ class VanillaRBSplitView(RBSplitView):
     def viewDidMoveToSuperview(self):
         pass
 
+    @objc.python_method
     def _recurseThroughSubviews(self, view):
         if hasattr(view, "vanillaWrapper"):
             vanillaWrapper = view.vanillaWrapper()

--- a/Lib/vanilla/vanillaSplitView2.py
+++ b/Lib/vanilla/vanillaSplitView2.py
@@ -1,6 +1,6 @@
 from warnings import warn
 from AppKit import *
-from vanillaBase import VanillaBaseObject
+from vanilla.vanillaBase import VanillaBaseObject
 
 import objc
 objc.setVerbose(True)

--- a/Lib/vanilla/vanillaSplitView2.py
+++ b/Lib/vanilla/vanillaSplitView2.py
@@ -181,6 +181,7 @@ class VanillaSplitViewDelegate(NSObject):
         # tell NSSplitView to mess everything up
         splitView.adjustSubviews()
 
+    @objc.python_method
     def _recursivelyResizeSubviews(self, view):
         for subview in view.subviews():
             if hasattr(subview, "vanillaWrapper"):

--- a/Lib/vanilla/vanillaTabs.py
+++ b/Lib/vanilla/vanillaTabs.py
@@ -1,5 +1,5 @@
 from AppKit import *
-from vanillaBase import VanillaBaseObject, _breakCycles, _sizeStyleMap, VanillaCallbackWrapper, \
+from vanilla.vanillaBase import VanillaBaseObject, _breakCycles, _sizeStyleMap, VanillaCallbackWrapper, \
         _reverseSizeStyleMap
 
 

--- a/Lib/vanilla/vanillaTextBox.py
+++ b/Lib/vanilla/vanillaTextBox.py
@@ -1,5 +1,5 @@
 from AppKit import *
-from vanillaBase import VanillaBaseControl
+from vanilla.vanillaBase import VanillaBaseControl
 
 
 _textAlignmentMap = {

--- a/Lib/vanilla/vanillaTextEditor.py
+++ b/Lib/vanilla/vanillaTextEditor.py
@@ -1,6 +1,7 @@
 from AppKit import *
 from vanilla.nsSubclasses import getNSSubclass
 from vanilla.vanillaBase import VanillaBaseObject, VanillaCallbackWrapper
+from vanilla.py23 import unicode
 
 
 class VanillaTextEditorDelegate(NSObject):

--- a/Lib/vanilla/vanillaTextEditor.py
+++ b/Lib/vanilla/vanillaTextEditor.py
@@ -1,6 +1,6 @@
 from AppKit import *
-from nsSubclasses import getNSSubclass
-from vanillaBase import VanillaBaseObject, VanillaCallbackWrapper
+from vanilla.nsSubclasses import getNSSubclass
+from vanilla.vanillaBase import VanillaBaseObject, VanillaCallbackWrapper
 
 
 class VanillaTextEditorDelegate(NSObject):

--- a/Lib/vanilla/vanillaTextEditor.py
+++ b/Lib/vanilla/vanillaTextEditor.py
@@ -28,7 +28,7 @@ class TextEditor(VanillaBaseObject):
                 self.w.open()
 
             def textEditorCallback(self, sender):
-                print "text entry!", sender.get()
+                print("text entry!", sender.get())
 
         TextEditorDemo()
 

--- a/Lib/vanilla/vanillaWindows.py
+++ b/Lib/vanilla/vanillaWindows.py
@@ -429,7 +429,7 @@ class Window(NSObject):
                     self.w.open()
 
                 def windowMoved(self, sender):
-                    print "window moved!", sender
+                    print("window moved!", sender)
 
             WindowBindDemo()
         """

--- a/Lib/vanilla/vanillaWindows.py
+++ b/Lib/vanilla/vanillaWindows.py
@@ -1,3 +1,4 @@
+import objc
 from AppKit import *
 from vanilla.vanillaBase import _breakCycles, _calcFrame, _setAttr, _delAttr, _flipFrame, \
         VanillaCallbackWrapper, VanillaError, VanillaBaseControl, osVersionCurrent, osVersion10_7, osVersion10_10
@@ -202,6 +203,7 @@ class Window(NSObject):
     def __delattr__(self, attr):
         _delAttr(Window, self, attr)
 
+    @objc.python_method
     def assignToDocument(self, document):
         """
         Add this window to the list of windows associated with a document.
@@ -274,6 +276,7 @@ class Window(NSObject):
         """
         self._window.makeMainWindow()
 
+    @objc.python_method
     def setTitle(self, title):
         """
         Set the title in the window's title bar.
@@ -320,6 +323,7 @@ class Window(NSObject):
         h -= titlebarHeight
         return (l, t, w, h)
 
+    @objc.python_method
     def setPosSize(self, posSize, animate=True):
         """
         Set the position and size of the window.
@@ -352,6 +356,7 @@ class Window(NSObject):
         """
         self._window.center()
 
+    @objc.python_method
     def move(self, x, y, animate=True):
         """
         Move the window by **x** units and **y** units.
@@ -361,6 +366,7 @@ class Window(NSObject):
         b = b - y
         self._window.setFrame_display_animate_(((l, b), (w, h)), True, animate)
 
+    @objc.python_method
     def resize(self, width, height, animate=True):
         """
         Change the size of the window to **width** and **height**.
@@ -368,6 +374,7 @@ class Window(NSObject):
         l, t, w, h = self.getPosSize()
         self.setPosSize((l, t, width, height), animate)
 
+    @objc.python_method
     def setDefaultButton(self, button):
         """
         Set the default button in the window.
@@ -379,6 +386,7 @@ class Window(NSObject):
         cell = button._nsObject.cell()
         self._window.setDefaultButtonCell_(cell)
 
+    @objc.python_method
     def bind(self, event, callback):
         """
         Bind a callback to an event.
@@ -429,6 +437,7 @@ class Window(NSObject):
             self._bindings[event] = []
         self._bindings[event].append(callback)
 
+    @objc.python_method
     def unbind(self, event, callback):
         """
         Unbind a callback from an event.
@@ -440,6 +449,7 @@ class Window(NSObject):
         """
         self._bindings[event].remove(callback)
 
+    @objc.python_method
     def _alertBindings(self, key):
         # test to see if the attr exists.
         # this is necessary because NSWindow
@@ -517,6 +527,7 @@ class Window(NSObject):
     # credit where credit is due: much of this was learned
     # from the PyObjC demo: WSTConnectionWindowControllerClass
 
+    @objc.python_method
     def addToolbar(self, toolbarIdentifier, toolbarItems, addStandardItems=True, displayMode="default", sizeStyle="default"):
         """
         Add a toolbar to the window.
@@ -648,6 +659,7 @@ class Window(NSObject):
             return self._toolbarItems
         return {}
 
+    @objc.python_method
     def addToolbarItem(self, itemData, index=None):
         """
         Add a toolbar item to the windows toolbar.
@@ -667,6 +679,7 @@ class Window(NSObject):
             index = self._toolbarDefaultItemIdentifiers.index(itemIdentifier)
             self._window.toolbar().insertItemWithItemIdentifier_atIndex_(itemIdentifier, index)
 
+    @objc.python_method
     def removeToolbarItem(self, itemIdentifier):
         """
         Remove a toolbar item by his identifier.
@@ -687,6 +700,7 @@ class Window(NSObject):
         self._toolbarDefaultItemIdentifiers.remove(itemIdentifier)
         del self._toolbarItems[itemIdentifier]
 
+    @objc.python_method
     def _createToolbarItem(self, itemData):
         itemIdentifier = itemData.get("itemIdentifier")
         if itemIdentifier is None:

--- a/Lib/vanilla/vanillaWindows.py
+++ b/Lib/vanilla/vanillaWindows.py
@@ -1,5 +1,5 @@
 from AppKit import *
-from vanillaBase import _breakCycles, _calcFrame, _setAttr, _delAttr, _flipFrame, \
+from vanilla.vanillaBase import _breakCycles, _calcFrame, _setAttr, _delAttr, _flipFrame, \
         VanillaCallbackWrapper, VanillaError, VanillaBaseControl, osVersionCurrent, osVersion10_7, osVersion10_10
 
 # PyObjC may not have these constants wrapped,


### PR DESCRIPTION
I based the current `py23` branch on the `yosemite` branch, since the latter seems more advanced than `master` (see my question at #31).

With this patch, I was able to compile the `SimpleApp` as well as the `TinyTextEditor` inside `Demos`, using the latest Python 3.5.2 from Python.org, the latest pyobjc 3.2.1 (released just today, finally with pre-compiled wheels on PyPI), and the latest py2app.

Here are the two standalone apps, with embedded python3.5:

https://www.dropbox.com/s/errd2truk2r9kja/TinyTextEditor.zip?dl=0
https://www.dropbox.com/s/9y6iquvx9ab3age/SimpleApp.zip?dl=0

Please let me know if this works for you as well,
Thanks.

/cc @typesupply @typemytype @justvanrossum 