### PR TITLE
Nicer values for the text offset @ "mini"

### DIFF
--- a/Lib/vanilla/vanillaCheckBox.py
+++ b/Lib/vanilla/vanillaCheckBox.py
@@ -120,7 +120,7 @@ class _CheckBoxManualBuild(VanillaBaseObject):
         textBoxPosSize = {
                 # left, top, height
                 "mini": (12, 5, 12),
-                "small": (14, 4, 14),
+                "small": (14, 6, 14),
                 "regular": (16, 3, 17)
                 }
         textBoxLeft, textBoxTop, textBoxHeight = textBoxPosSize[sizeStyle]

--- a/Lib/vanilla/vanillaCheckBox.py
+++ b/Lib/vanilla/vanillaCheckBox.py
@@ -119,7 +119,7 @@ class _CheckBoxManualBuild(VanillaBaseObject):
         # adjust the position of the text button in relation to the check box
         textBoxPosSize = {
                 # left, top, height
-                "mini": (10, 4, 12),
+                "mini": (12, 5, 12),
                 "small": (14, 4, 14),
                 "regular": (16, 3, 17)
                 }


### PR DESCRIPTION
Can we use these values? They look better to me. With the old values the text was always too tight to the check mark.