### PR TITLE
Python 3: Use objc.super instead of super

### DIFF
--- a/Lib/vanilla/vanillaSplitView.py
+++ b/Lib/vanilla/vanillaSplitView.py
@@ -6,7 +6,7 @@ from vanilla.externalFrameworks.RBSplitView import RBSplitView, RBSplitSubview
 class VanillaRBSplitView(RBSplitView):
 
     def init(self):
-        self = super(VanillaRBSplitView, self).initWithFrame_(((0, 0), (0, 0)))
+        self = objc.super(VanillaRBSplitView, self).initWithFrame_(((0, 0), (0, 0)))
         image = NSImage.imageNamed_("RBSplitViewThumb8")
         if image is not None:
             image.setFlipped_(True)


### PR DESCRIPTION
When clicking "List" when running vanilla/test/testAll.py:
```
Traceback (most recent call last):
  File "Lib/vanilla/vanillaBase.py", line 212, in action_
    self.callback(sender)
  File "Lib/vanilla/test/testAll.py", line 595, in openTestCallback
    ListTest(self.w.drawGrid.get())
  File "Lib/vanilla/test/testAll.py", line 364, in __init__
    self.w.splitView = SplitView((0, 0, -0, -0), paneDescriptions, isVertical=False)
  File "Lib/vanilla/vanillaSplitView.py", line 93, in __init__
    self._setupView(self.rbSplitViewClass, posSize)
  File "Lib/vanilla/vanillaBase.py", line 31, in _setupView
    self._nsObject = cls(self)
  File "Lib/vanilla/nsSubclasses.py", line 10, in __new__
    self = cls.alloc().init()
  File "Lib/vanilla/vanillaSplitView.py", line 10, in init
    self = super(VanillaRBSplitView, self).initWithFrame_(((0, 0), (0, 0)))
AttributeError: 'super' object has no attribute 'initWithFrame_'
```