### PR TITLE
Make sure new NSViews have a non-zero size upon creation.

### DIFF
--- a/Lib/vanilla/vanillaBase.py
+++ b/Lib/vanilla/vanillaBase.py
@@ -30,6 +30,7 @@ class VanillaBaseObject(object):
         self._testForDeprecatedAttributes()
         cls = getNSSubclass(classOrName)
         self._nsObject = cls(self)
+        self._nsObject.setFrame_(((0, 0), (10000, 10000)))
         self._posSize = posSize
         self._setCallback(callback)
         self._setAutosizingFromPosSize(posSize)

--- a/Lib/vanilla/vanillaBase.py
+++ b/Lib/vanilla/vanillaBase.py
@@ -30,6 +30,8 @@ class VanillaBaseObject(object):
         self._testForDeprecatedAttributes()
         cls = getNSSubclass(classOrName)
         self._nsObject = cls(self)
+        # Set the frame to something non-zero, so the autosizing machinery works
+        # well for nested views, even when there's no parent view yet.
         self._nsObject.setFrame_(((0, 0), (10000, 10000)))
         self._posSize = posSize
         self._setCallback(callback)

--- a/Lib/vanilla/vanillaTabs.py
+++ b/Lib/vanilla/vanillaTabs.py
@@ -9,6 +9,7 @@ class VanillaTabItem(VanillaBaseObject):
 
     def __init__(self, title):
         self._tabItem = self.nsTabViewItemClass.alloc().initWithIdentifier_(title)
+        self._tabItem.view().setFrame_(((0, 0), (10000, 10000)))
         self._tabItem.setLabel_(title)
 
     def _getContentView(self):

--- a/Lib/vanilla/vanillaTabs.py
+++ b/Lib/vanilla/vanillaTabs.py
@@ -9,6 +9,9 @@ class VanillaTabItem(VanillaBaseObject):
 
     def __init__(self, title):
         self._tabItem = self.nsTabViewItemClass.alloc().initWithIdentifier_(title)
+        # Set the frame to something non-zero, so the autosizing machinery works
+        # well for nested views, even when there's no parent view yet. That is
+        # the case for the tabs that are not visible upon creation.
         self._tabItem.view().setFrame_(((0, 0), (10000, 10000)))
         self._tabItem.setLabel_(title)
 


### PR DESCRIPTION
This seems to fix #47, as it seems the problem is caused by a view's frame having a `(0, 0)` size, which confuses Cocoa's autosize machinery.