### PR TITLE
Move positioning hack from VanillaBaseObject to Group and Tabs

### DIFF
--- a/Lib/vanilla/vanillaBase.py
+++ b/Lib/vanilla/vanillaBase.py
@@ -30,9 +30,6 @@ class VanillaBaseObject(object):
         self._testForDeprecatedAttributes()
         cls = getNSSubclass(classOrName)
         self._nsObject = cls(self)
-        # Set the frame to something non-zero, so the autosizing machinery works
-        # well for nested views, even when there's no parent view yet.
-        self._nsObject.setFrame_(((0, 0), (10000, 10000)))
         self._posSize = posSize
         self._setCallback(callback)
         self._setAutosizingFromPosSize(posSize)

--- a/Lib/vanilla/vanillaGroup.py
+++ b/Lib/vanilla/vanillaGroup.py
@@ -80,6 +80,12 @@ class Group(VanillaBaseObject):
             blendingMode = _blendingModeMap[blendingMode]
             self._visualEffectGroup.getNSVisualEffectView().setBlendingMode_(blendingMode)
 
+    def _setupView(self, classOrName, posSize, callback=None):
+        super(Group, self)._setupView(classOrName, posSize, callback=None)
+        # Set the frame to something non-zero, so the autosizing machinery works
+        # well for nested views, even when there's no parent view yet.
+        self._nsObject.setFrame_(((0, 0), (10000, 10000)))
+
     def __setattr__(self, attr, value):
         # __init__
         if not hasattr(self, "_visualEffectGroup") or attr == "_visualEffectGroup":

--- a/Lib/vanilla/vanillaTabs.py
+++ b/Lib/vanilla/vanillaTabs.py
@@ -112,6 +112,12 @@ class Tabs(VanillaBaseObject):
         """
         return self._nsObject
 
+    def _setupView(self, classOrName, posSize, callback=None):
+        super(Tabs, self)._setupView(classOrName, posSize, callback=None)
+        # Set the frame to something non-zero, so the autosizing machinery works
+        # well for nested views, even when there's no parent view yet.
+        self._nsObject.setFrame_(((0, 0), (10000, 10000)))
+
     def _adjustPosSize(self, frame):
         if self._nsObject.tabViewType() == NSNoTabsNoBorder:
             return frame


### PR DESCRIPTION
…this keeps solving #47, yet fixes typemytype/drawbot#155

I still think the hack should be replaced with a proper solution (perhaps as suggested by @typemytype in  #47), but at least this change reduces the damage of the hack.

@typemytype: you had two cases that were affected by the hack, can you see whether those workarounds are still needed with this change?