### PR TITLE
never do `from AppKit import *`

### DIFF
--- a/Lib/vanilla/dialogs.py
+++ b/Lib/vanilla/dialogs.py
@@ -1,7 +1,7 @@
 import objc
 from objc import selector
 from Foundation import NSObject
-from AppKit import *
+from AppKit import NSAlert, NSSavePanel, NSOpenPanel, NSInformationalAlertStyle, NSAlertFirstButtonReturn, NSAlertSecondButtonReturn, NSAlertThirdButtonReturn, NSOKButton
 from vanilla.py23 import python_method
 
 

--- a/Lib/vanilla/test/testAll.py
+++ b/Lib/vanilla/test/testAll.py
@@ -2,7 +2,8 @@ from __future__ import print_function
 import time
 import os
 import sys
-from AppKit import *
+from Foundation import NSObject, NSURL, NSString
+from AppKit import NSApplication, NSView, NSColor, NSImage, NSCursor, NSSegmentedControl, NSSegmentSwitchTrackingSelectOne, NSRectFill, NSToolbarPrintItemIdentifier, NSToolbarFlexibleSpaceItemIdentifier, NSToolbarCustomizeToolbarItemIdentifier
 import vanilla
 try:
     reload(vanilla)

--- a/Lib/vanilla/test/testTools.py
+++ b/Lib/vanilla/test/testTools.py
@@ -1,4 +1,5 @@
-from AppKit import *
+from Foundation import NSObject
+from AppKit import NSApplication, NSMenu, NSMenuItem
 from PyObjCTools import AppHelper
 
 

--- a/Lib/vanilla/vanillaBase.py
+++ b/Lib/vanilla/vanillaBase.py
@@ -1,5 +1,6 @@
 import platform
-from AppKit import *
+from Foundation import NSObject
+from AppKit import NSFont, NSRegularControlSize, NSSmallControlSize, NSMiniControlSize, NSViewMinXMargin, NSViewWidthSizable, NSViewMaxXMargin, NSViewMaxYMargin, NSViewHeightSizable, NSViewMinYMargin
 from distutils.version import StrictVersion
 from vanilla.nsSubclasses import getNSSubclass
 

--- a/Lib/vanilla/vanillaBox.py
+++ b/Lib/vanilla/vanillaBox.py
@@ -1,4 +1,4 @@
-from AppKit import *
+from AppKit import NSBox, NSColor, NSFont, NSSmallControlSize, NSNoTitle, NSLineBorder, NSBoxSeparator
 from vanilla.vanillaBase import VanillaBaseObject, _breakCycles, osVersionCurrent, osVersion10_10
 
 

--- a/Lib/vanilla/vanillaButton.py
+++ b/Lib/vanilla/vanillaButton.py
@@ -1,4 +1,4 @@
-from AppKit import *
+from AppKit import NSButton, NSImage, NSBundle, NSRoundedBezelStyle, NSShadowlessSquareBezelStyle, NSHelpButtonBezelStyle, NSMomentaryPushInButton, NSCommandKeyMask, NSAlternateKeyMask, NSAlternateKeyMask, NSShiftKeyMask, NSAlphaShiftKeyMask, NSHelpFunctionKey, NSHomeFunctionKey, NSEndFunctionKey, NSPageUpFunctionKey, NSPageDownFunctionKey, NSDeleteFunctionKey, NSLeftArrowFunctionKey, NSRightArrowFunctionKey, NSUpArrowFunctionKey, NSDownArrowFunctionKey, NSImageLeft, NSImageRight, NSImageAbove, NSImageBelow, NSImageOnly, NSRightTextAlignment, NSLeftTextAlignment, NSNoCellMask
 from vanilla.vanillaBase import VanillaBaseControl
 
 

--- a/Lib/vanilla/vanillaCheckBox.py
+++ b/Lib/vanilla/vanillaCheckBox.py
@@ -1,4 +1,4 @@
-from AppKit import *
+from AppKit import NSSwitchButton, NSShadowlessSquareBezelStyle, NSLeftTextAlignment, NSNoCellMask
 from vanilla.vanillaButton import Button
 from vanilla.vanillaBase import osVersionCurrent, osVersion10_10, VanillaBaseObject
 

--- a/Lib/vanilla/vanillaColorWell.py
+++ b/Lib/vanilla/vanillaColorWell.py
@@ -1,4 +1,4 @@
-from AppKit import *
+from AppKit import NSColorWell, NSColorPanel
 from vanilla.vanillaBase import VanillaBaseObject
 
 

--- a/Lib/vanilla/vanillaDatePicker.py
+++ b/Lib/vanilla/vanillaDatePicker.py
@@ -1,5 +1,5 @@
-from Foundation import *
-from AppKit import *
+# from Foundation import *
+from AppKit import NSDatePicker, NSClockAndCalendarDatePickerStyle, NSTextFieldAndStepperDatePickerStyle, NSHourMinuteDatePickerElementFlag, NSHourMinuteSecondDatePickerElementFlag, NSYearMonthDatePickerElementFlag, NSYearMonthDayDatePickerElementFlag
 from vanilla.vanillaBase import VanillaBaseControl
 
 

--- a/Lib/vanilla/vanillaDrawer.py
+++ b/Lib/vanilla/vanillaDrawer.py
@@ -1,5 +1,5 @@
 from Foundation import NSMaxXEdge, NSMaxYEdge, NSMinXEdge, NSMinYEdge
-from AppKit import *
+from AppKit import NSDrawer
 from vanilla.vanillaBase import VanillaBaseObject, _breakCycles
 
 

--- a/Lib/vanilla/vanillaEditText.py
+++ b/Lib/vanilla/vanillaEditText.py
@@ -1,4 +1,4 @@
-from AppKit import *
+from AppKit import NSTextField, NSSecureTextField
 from vanilla.vanillaBase import VanillaBaseControl, VanillaCallbackWrapper
 
 

--- a/Lib/vanilla/vanillaGradientButton.py
+++ b/Lib/vanilla/vanillaGradientButton.py
@@ -1,4 +1,4 @@
-from AppKit import *
+from AppKit import NSSmallSquareBezelStyle
 from vanilla.vanillaButton import ImageButton
 
 

--- a/Lib/vanilla/vanillaImageView.py
+++ b/Lib/vanilla/vanillaImageView.py
@@ -1,4 +1,4 @@
-from AppKit import *
+from AppKit import NSImageView, NSImage, NSImageAlignCenter, NSImageAlignLeft, NSImageAlignRight, NSImageAlignTop, NSImageAlignTopLeft, NSImageAlignTopRight, NSImageAlignBottom, NSImageAlignBottomLeft, NSImageAlignBottomRight, NSScaleProportionally, NSScaleNone, NSScaleToFit
 from vanilla.vanillaBase import VanillaBaseObject
 
 _imageAlignmentMap = {

--- a/Lib/vanilla/vanillaLevelIndicator.py
+++ b/Lib/vanilla/vanillaLevelIndicator.py
@@ -1,4 +1,4 @@
-from AppKit import *
+from AppKit import NSLevelIndicator, NSTickMarkAbove, NSTickMarkBelow, NSDiscreteCapacityLevelIndicatorStyle, NSContinuousCapacityLevelIndicatorStyle, NSRatingLevelIndicatorStyle, NSRelevancyLevelIndicatorStyle
 from vanilla.vanillaBase import VanillaBaseControl
 
 # This control is available in OS 10.4+.

--- a/Lib/vanilla/vanillaList.py
+++ b/Lib/vanilla/vanillaList.py
@@ -1,7 +1,8 @@
 import time
 import objc
-from Foundation import NSKeyValueObservingOptionNew, NSKeyValueObservingOptionOld, NSNotFound
-from AppKit import *
+from Foundation import NSObject, NSArray, NSMutableArray, NSDictionary, NSMutableDictionary, NSMutableIndexSet, NSString, NSAttributedString, NSKeyValueObservingOptionNew, NSKeyValueObservingOptionOld, NSNotFound
+from AppKit import NSApp, NSTableView, NSTableColumn, NSArrayController, NSScrollView, NSSwitchButton, NSButtonCell, NSSliderCell, NSPopUpButtonCell, NSImageCell, NSSegmentedCell, NSFont, NSImage, NSReturnTextMovement, NSTabTextMovement, NSBacktabTextMovement, NSIllegalTextMovement, NSNotification, NSDragOperationNone, NSTableViewDropOn, NSDragOperationCopy, NSBezelBorder, NSFocusRingTypeNone, NSTableViewSolidVerticalGridLineMask, NSTableViewSolidHorizontalGridLineMask, NSTableViewUniformColumnAutoresizingStyle, NSTableColumnNoResizing, NSTableColumnUserResizingMask, NSTableColumnAutoresizingMask, NSCreatesSortDescriptorBindingOption, NSBackspaceCharacter, NSDeleteFunctionKey, NSDeleteCharacter, NSUpArrowFunctionKey, NSDownArrowFunctionKey, NSLeftArrowFunctionKey, NSRightArrowFunctionKey, NSPageUpFunctionKey, NSPageDownFunctionKey, NSSmallControlSize, NSMiniControlSize, NSSegmentSwitchTrackingSelectOne
+
 from vanilla.py23 import basestring, range, unichr, python_method
 from vanilla.nsSubclasses import getNSSubclass
 from vanilla.vanillaBase import VanillaBaseObject, VanillaError, VanillaCallbackWrapper

--- a/Lib/vanilla/vanillaPathControl.py
+++ b/Lib/vanilla/vanillaPathControl.py
@@ -1,4 +1,4 @@
-from AppKit import *
+from AppKit import NSPathControl, NSPathStyleStandard, NSColor, NSFocusRingTypeNone
 from vanilla.vanillaBase import VanillaBaseControl
 
 class PathControl(VanillaBaseControl):

--- a/Lib/vanilla/vanillaPopover.py
+++ b/Lib/vanilla/vanillaPopover.py
@@ -1,5 +1,7 @@
 import weakref
-from AppKit import *
+from Foundation import NSObject, NSRect, NSMakeRect, NSZeroRect
+from AppKit import NSView, NSViewController, NSPopover, NSMinXEdgem, NSMaxXEdge, NSMinYEdge, NSMaxYEdge, NSPopoverBehaviorApplicationDefined, NSPopoverBehaviorTransient, NSPopoverBehaviorSemitransient
+
 from vanilla.vanillaBase import VanillaBaseObject, _breakCycles
 from vanilla.nsSubclasses import getNSSubclass
 

--- a/Lib/vanilla/vanillaProgressBar.py
+++ b/Lib/vanilla/vanillaProgressBar.py
@@ -1,4 +1,5 @@
-from AppKit import *
+from Foundation import NSDate
+from AppKit import NSRunLoop, NSProgressIndicator, NSProgressIndicatorBarStyle, NSProgressIndicatorSpinningStyle
 from vanilla.vanillaBase import VanillaBaseObject, _sizeStyleMap, osVersion10_11, osVersionCurrent
 
 class ProgressBar(VanillaBaseObject):

--- a/Lib/vanilla/vanillaProgressSpinner.py
+++ b/Lib/vanilla/vanillaProgressSpinner.py
@@ -1,4 +1,4 @@
-from AppKit import *
+from AppKit import NSProgressIndicator, NSProgressIndicatorSpinningStyle
 from vanilla.vanillaBase import VanillaBaseObject, _sizeStyleMap
 
 

--- a/Lib/vanilla/vanillaRadioGroup.py
+++ b/Lib/vanilla/vanillaRadioGroup.py
@@ -1,4 +1,4 @@
-from AppKit import *
+from AppKit import NSMatrix, NSRadioButton, NSButtonCell, NSRadioModeMatrix, NSFont, NSCellDisabled
 from vanilla.py23 import range
 from vanilla.vanillaBase import VanillaBaseControl, _sizeStyleMap
 

--- a/Lib/vanilla/vanillaScrollView.py
+++ b/Lib/vanilla/vanillaScrollView.py
@@ -1,4 +1,4 @@
-from AppKit import *
+from AppKit import NSScrollView, NSBezelBorder
 from vanilla.vanillaBase import VanillaBaseObject
 
 

--- a/Lib/vanilla/vanillaSegmentedButton.py
+++ b/Lib/vanilla/vanillaSegmentedButton.py
@@ -1,4 +1,5 @@
-from AppKit import *
+from AppKit import NSSegmentedControl, NSSegmentedCell, NSImage, NSSegmentSwitchTrackingSelectOne, NSSegmentSwitchTrackingSelectAny, NSSegmentSwitchTrackingMomentary
+
 from vanilla.py23 import range
 from vanilla.vanillaBase import VanillaBaseControl
 

--- a/Lib/vanilla/vanillaSlider.py
+++ b/Lib/vanilla/vanillaSlider.py
@@ -1,4 +1,4 @@
-from AppKit import *
+from AppKit import NSSlider, NSTickMarkLeft, NSTickMarkRight, NSTickMarkAbove, NSTickMarkBelow
 from vanilla.vanillaBase import VanillaBaseControl, VanillaError
 
 _tickPositionMap = {

--- a/Lib/vanilla/vanillaSplitView.py
+++ b/Lib/vanilla/vanillaSplitView.py
@@ -1,5 +1,7 @@
 from warnings import warn
-from AppKit import *
+from Foundation import NSObject
+from AppKit import NSSplitView, NSSplitViewDividerStylePaneSplitter, NSSplitViewDividerStyleThin, NSSplitViewDividerStyleThick, NSViewWidthSizable, NSViewHeightSizable
+
 from vanilla.vanillaBase import VanillaBaseObject
 from vanilla.py23 import python_method
 

--- a/Lib/vanilla/vanillaTabs.py
+++ b/Lib/vanilla/vanillaTabs.py
@@ -1,4 +1,5 @@
-from AppKit import *
+from Foundation import NSObject
+from AppKit import NSTabView, NSTabViewItem, NSNoTabsNoBorder, NSFont
 from vanilla.vanillaBase import VanillaBaseObject, _breakCycles, _sizeStyleMap, VanillaCallbackWrapper, \
         _reverseSizeStyleMap
 

--- a/Lib/vanilla/vanillaTextBox.py
+++ b/Lib/vanilla/vanillaTextBox.py
@@ -1,4 +1,4 @@
-from AppKit import *
+from AppKit import NSTextField, NSAttributedString, NSLeftTextAlignment, NSRightTextAlignment, NSCenterTextAlignment, NSJustifiedTextAlignment, NSNaturalTextAlignment
 from vanilla.vanillaBase import VanillaBaseControl
 
 

--- a/Lib/vanilla/vanillaTextEditor.py
+++ b/Lib/vanilla/vanillaTextEditor.py
@@ -1,4 +1,5 @@
-from AppKit import *
+from Foundation import NSObject
+from AppKit import NSTextView, NSScrollView, NSBezelBorder, NSViewWidthSizable, NSViewHeightSizable
 from vanilla.nsSubclasses import getNSSubclass
 from vanilla.vanillaBase import VanillaBaseObject, VanillaCallbackWrapper
 from vanilla.py23 import unicode

--- a/Lib/vanilla/vanillaWindows.py
+++ b/Lib/vanilla/vanillaWindows.py
@@ -1,5 +1,8 @@
 import objc
-from AppKit import *
+from Foundation import NSObject
+from AppKit import NSApp, NSWindow, NSPanel, NSScreen, NSWindowController, NSToolbar, NSToolbarItem, NSImage, NSNormalWindowLevel, NSFloatingWindowLevel, NSClosableWindowMask, NSMiniaturizableWindowMask, NSResizableWindowMask, NSTexturedBackgroundWindowMask, NSUnifiedTitleAndToolbarWindowMask, NSHUDWindowMask, NSUtilityWindowMask, NSTitledWindowMask, NSBorderlessWindowMask, NSBackingStoreBuffered, NSToolbarFlexibleSpaceItemIdentifier, NSToolbarSpaceItemIdentifier, NSToolbarSeparatorItemIdentifier, NSToolbarCustomizeToolbarItemIdentifier, NSToolbarPrintItemIdentifier, NSToolbarShowFontsItemIdentifier, NSToolbarShowColorsItemIdentifier, NSToolbarDisplayModeDefault, NSToolbarDisplayModeIconAndLabel, NSToolbarDisplayModeIconOnly, NSToolbarDisplayModeLabelOnly, NSToolbarSizeModeDefault, NSToolbarSizeModeRegular, NSToolbarSizeModeSmall
+
+
 from vanilla.vanillaBase import _breakCycles, _calcFrame, _setAttr, _delAttr, _flipFrame, \
         VanillaCallbackWrapper, VanillaError, VanillaBaseControl, osVersionCurrent, osVersion10_7, osVersion10_10
 from vanilla.py23 import python_method
@@ -7,22 +10,20 @@ from vanilla.py23 import python_method
 # PyObjC may not have these constants wrapped,
 # so test and fallback if needed.
 try:
-    NSWindowCollectionBehaviorFullScreenPrimary
-    NSWindowCollectionBehaviorFullScreenAuxiliary
-except NameError:
+    from AppKit import NSWindowCollectionBehaviorFullScreenPrimary, NSWindowCollectionBehaviorFullScreenAuxiliary
+except ImportError:
     NSWindowCollectionBehaviorFullScreenPrimary = 1 << 7
     NSWindowCollectionBehaviorFullScreenAuxiliary = 1 << 8
 
 try:
-    NSWindowTitleVisible
-    NSWindowTitleHidden
-except NameError:
+    from AppKit import NSWindowTitleVisible, NSWindowTitleHidden
+except ImportError:
     NSWindowTitleVisible  = 0
     NSWindowTitleHidden = 1
 
 try:
-    NSFullSizeContentViewWindowMask
-except NameError:
+    from AppKit import NSFullSizeContentViewWindowMask
+except ImportError:
     NSFullSizeContentViewWindowMask = 1 << 15
 
 


### PR DESCRIPTION
This reduces the time needed to do `import vanilla` from 3.5s to 0.5s
(one my macBook).

The first time a script calls `from AppKit import *`, it takes several seconds. Subsequent calls will be much faster.