### PR TITLE
Minor docstring fixes

### DIFF
--- a/Lib/vanilla/vanillaWindows.py
+++ b/Lib/vanilla/vanillaWindows.py
@@ -775,7 +775,7 @@ class FloatingWindow(Window):
     """
     A window that floats above all other windows.
 
-    To add a control to a window, simply set it as an attribute of the window.
+    To add a control to a window, simply set it as an attribute of the window.::
 
         from vanilla import *
 
@@ -842,7 +842,7 @@ class HUDFloatingWindow(FloatingWindow):
     """
     A window that floats above all other windows and has the HUD appearance.
 
-    To add a control to a window, simply set it as an attribute of the window.
+    To add a control to a window, simply set it as an attribute of the window.::
 
         from vanilla import *
 


### PR DESCRIPTION
I added those fixes to hopefully fix the code example on http://ts-vanilla.readthedocs.io/en/latest/objects/FloatingWindow.html.

The `HUDFloatingWindow` doesn’t seem to be included in the documentation at all, although there is a docstring. Is there a reason for that?

Also, I don’t know why the first table (options for *fullScreenMode*) on http://ts-vanilla.readthedocs.io/en/latest/objects/Window.html doesn’t render properly