### PR TITLE
Fixes a zero division error in a SplitView

### DIFF
--- a/Lib/vanilla/vanillaSplitView.py
+++ b/Lib/vanilla/vanillaSplitView.py
@@ -146,7 +146,10 @@ class VanillaSplitViewDelegate(NSObject):
         dividerThickness = (len(paneDescriptions) - 1) * splitView.dividerThickness()
         desiredSize = sum(viewSizes.values()) + dividerThickness
         remainder = splitViewSize - desiredSize
-        viewAdjustment = int(round(remainder / (len(minMaxViews) + len(flexibleViews))))
+        totalNonFixedViews = len(minMaxViews) + len(flexibleViews)
+        if totalNonFixedViews:
+            viewAdjustment = int(round(remainder / (len(minMaxViews) + len(flexibleViews))))
+        else: viewAdjustment = 0
         # now apply the difference to minMaxViews respecting the min/max values
         for identifier in minMaxViews:
             for paneDescription in paneDescriptions:
@@ -165,7 +168,9 @@ class VanillaSplitViewDelegate(NSObject):
             viewSizes[identifier] = test
         # recalculate the remainder
         remainder = splitViewSize - desiredSize
-        viewAdjustment = int(round(remainder / (len(minMaxViews) + len(flexibleViews))))
+        if totalNonFixedViews:
+            viewAdjustment = int(round(remainder / (len(minMaxViews) + len(flexibleViews))))
+        else: viewAdjustment = 0
         # apply to the flexible views
         for identifier in flexibleViews:
             viewSizes[identifier] += viewAdjustment


### PR DESCRIPTION
Fixes a zero division error in SplitView when all views are set to an absolute size that together is still smaller than their container.

This fix seems to bring back the behavior that the SplitView used to have, where the remaining space is just added to the first view. I know the docstring says “it's the responsibility of the entity that set the pane sizes to make sure that they aren't doing anything crazy” so maybe this isn't the *best* fix, but I think it might be better than a zero division error.

```python
import vanilla

class TestWindow:
    def __init__(self):
        self.w = vanilla.Window((200, 200), maxSize=(2000, 2000))
        self.pane1 = vanilla.Box((0, 0, -0, -0))
        self.pane2 = vanilla.Box((0, 0, -0, -0))
        panelDescriptors = [
            dict(view=self.pane1, identifier="pane1", size=30),
            dict(view=self.pane2, identifier="pane2", size=30)]
        self.w.splitView = vanilla.SplitView((0, 0, -0, -0), panelDescriptors)
        self.w.open()

TestWindow()
```
