### PR TITLE
removed objc.setVerbose() call, which I don't think is needed, and is…

### DIFF
--- a/Lib/vanilla/vanillaSplitView.py
+++ b/Lib/vanilla/vanillaSplitView.py
@@ -6,9 +6,6 @@ import vanilla
 from vanilla.vanillaBase import VanillaBaseObject, _breakCycles
 from vanilla.py23 import python_method
 
-import objc
-objc.setVerbose(True)
-
 
 _dividerStyleMap = {
     "splitter": NSSplitViewDividerStylePaneSplitter,


### PR DESCRIPTION
… in fact deprecated in recent versions of PyObjC, in favor of objc.options.verbose