### PR TITLE
Prevent exception in macOS 10.12 and below

### DIFF
--- a/Lib/vanilla/dragAndDrop.py
+++ b/Lib/vanilla/dragAndDrop.py
@@ -11,11 +11,15 @@ draggingFormationMap = dict(
     stack=AppKit.NSDraggingFormationStack,
     list=AppKit.NSDraggingFormationList
 )
+try:
+    NSPasteboardTypeFileURL = AppKit.NSPasteboardTypeFileURL
+except:
+    NSPasteboardTypeFileURL = "public.file-url"
 
 pasteboardTypeMap = dict(
     string=AppKit.NSPasteboardTypeString,
     plist="dev.robotools.vanilla.propertyList",
-    fileURL=AppKit.NSPasteboardTypeFileURL
+    fileURL=NSPasteboardTypeFileURL
 )
 
 def startDraggingSession(


### PR DESCRIPTION
This is the only thing I found so far that prevents the usage of vanilla on older macs. I’m interested in macOS down to 10.11 as that is what Glyphs 3 is supporting. 